### PR TITLE
remove unnecessary console.log from server code

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -20,8 +20,6 @@ app.get('/campaigns/:campaignId/stats', (req, res) => { // handle requests for a
       console.log(error);
       return;
     }
-    // eslint-disable-next-line no-console
-    console.log(results[1][0]);
     res.status(200).send(results[1][0]);
   });
 });


### PR DESCRIPTION
@FEC-Kickstand/kickstand a tiny change to remove a leftover test console.log and a chance to try out the team tagging in comments.