### PR TITLE
add an unstyled funding progress bar

### DIFF
--- a/client/components/ProgressBar.jsx
+++ b/client/components/ProgressBar.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import style from '../style.css';
+
+const ProgressBar = (props) => {
+  const { goal } = props;
+  const { fill } = props;
+  return (
+    <progress max="1" value={(fill / goal).toString()} className={style.progressBar} />
+  );
+};
+
+ProgressBar.propTypes = {
+  goal: PropTypes.number.isRequired,
+  fill: PropTypes.number.isRequired,
+};
+
+export default ProgressBar;

--- a/client/components/statsTrack.jsx
+++ b/client/components/statsTrack.jsx
@@ -3,6 +3,7 @@ import Promise from 'bluebird';
 import $ from 'jquery';
 import Moment from 'moment';
 import BackButton from './BackButton';
+import ProgressBar from './ProgressBar';
 import style from '../style.css';
 
 class StatsTrack extends React.Component {
@@ -82,6 +83,7 @@ class StatsTrack extends React.Component {
 
     return (
       <div className={style.fundingTracker}>
+        <ProgressBar fill={pledged} goal={goal} />
         <div className={style.pledgedAmount}>
           <h2>{pledgeAmount}</h2>
         </div>

--- a/client/style.css
+++ b/client/style.css
@@ -60,6 +60,10 @@ table {
   flex-direction: column;
 }
 
+.progressBar {
+  background-color: #E9E9E9;
+}
+
 .supertext {
   font-weight: 500;
   font-size: 22px;


### PR DESCRIPTION
@FEC-Kickstand/kickstand A bar at the top of the widget giving a visual representation of how much of the funding goal has been pledged.