### PR TITLE
Progress bar styling

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -30,6 +30,7 @@ footer, header, hgroup, menu, nav, section {
 }
 body {
   line-height: 1;
+  box-sizing: border-box;
 }
 ol, ul {
   list-style: none;

--- a/client/style.css
+++ b/client/style.css
@@ -8,7 +8,7 @@ h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
 del, dfn, em, img, ins, kbd, q, s, samp,
 small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
+b, u, i, center, progress,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
@@ -62,7 +62,18 @@ table {
 }
 
 .progressBar {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 3px;
+  width: 90%;
+  margin-bottom: 15px;
+}
+.progressBar::-webkit-progress-bar {
   background-color: #E9E9E9;
+}
+
+.progressBar::-webkit-progress-value {
+  color: #027462;
 }
 
 .supertext {

--- a/client/style.css
+++ b/client/style.css
@@ -85,6 +85,10 @@ table {
   width: 90%;
 }
 
+.backingButton:hover {
+  background-color: #027C62
+}
+
 .pledgedAmount {
   composes: supertext;
   color: #009E74;


### PR DESCRIPTION
@FEC-Kickstand/kickstand I have added a funding progress bar to the top of the widget. It should match the size and colouring of the live site and will also fill up as the `Back this Campaign` button is clicked.