### PR TITLE
change div id in ReactDOM.render statement to be more specific

### DIFF
--- a/client/index.jsx
+++ b/client/index.jsx
@@ -18,6 +18,6 @@ class App extends React.Component {
   }
 }
 
-ReactDOM.render(<App />, document.getElementById('App'));
+ReactDOM.render(<App />, document.getElementById('funding-widget'));
 
 export default App;

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
       crossorigin="anonymous"></script>
   </head>
   <body>
-    <div id="App"></div>
+    <div id="funding-widget"></div>
     <script type="text/javascript" src="bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
@FEC-Kickstand/kickstand I think we should all go in and change our ReactDOM.render statements to look for a div id other than "App" so that we can keep things separated in the dom.
For example, I changed mine to render in the 'funding-widget' id instead of just 'App', as per the example proxy.